### PR TITLE
Update create_semantic_types.cql

### DIFF
--- a/src/neo4j_loader/cypher/create_semantic_types.cql
+++ b/src/neo4j_loader/cypher/create_semantic_types.cql
@@ -1,3 +1,7 @@
+MATCH (a:Concept)-[:CODE]->(:Code)<-[:CODE]-(:Concept)-[:STY]->(b:Semantic)
+WHERE SIZE((a)-[:STY]->(:Semantic)) = 0
+MERGE (a)-[:STY]->(b);
+
 MATCH (a:Code)<--(b:Concept) WHERE 
 a.SAB IN ['UBERON','CL','CCF'] AND SIZE((b)-->(:Semantic)) = 0
 CALL { WITH b


### PR DESCRIPTION
Added a first statement to compensate for having more HCUIs in new construction. What it does is uses the HCUI-Code-CUI relationships to create semantic types for the ones that would have had dbXrefs before doing the hierarchical traversal. Note that this MERGE approach does not limit to one Semantic per HCUI (that was not really needed and could at some point change the rest of this to be more general also).