### PR TITLE
Log4J CVE Mitigation for Neo4j

### DIFF
--- a/neo4j/neo4j.conf
+++ b/neo4j/neo4j.conf
@@ -353,6 +353,9 @@ dbms.jvm.additional=-XX:+DebugNonSafepoints
 
 # Disable logging JMX endpoint.
 dbms.jvm.additional=-Dlog4j2.disable.jmx=true
+# Log4J CVE Mitigation for Neo4j (in addition to the above line)
+# See: https://community.neo4j.com/t/log4j-cve-mitigation-for-neo4j/48856
+dbms.jvm.additional=-Dlog4j2.formatMsgNoLookups=true
 
 #********************************************************************
 # Wrapper Windows NT/2000/XP Service Properties

--- a/server/build-server.sh
+++ b/server/build-server.sh
@@ -8,6 +8,7 @@ usage()
   echo " -r Run server after building"
   echo " -R Reinstall VENV at ${VENV}"
   echo " -v Verbose output"
+  echo " -c Build the client from the openapi spec"
   echo " -h Help"
   exit 2
 }

--- a/server/client_programs/terms_term_id_terms.py
+++ b/server/client_programs/terms_term_id_terms.py
@@ -101,6 +101,7 @@ def process_term_id_file(filename: str) -> None:
 
 # https://pypi.org/project/openapi-python-client/
 client = Client(base_url=args.url)
+# client = AuthenticatedClient(base_url=args.url, token="my-friend-bob")
 timeout: int = 60
 if args.verbose is True:
     eprint(f"Default client timeout (sec): {client.get_timeout()}")


### PR DESCRIPTION
I've tested this on dev by rebuilding the image and viewing it with the Neo4j web browser and then trying to delete a node and failing. I also ran the 'server/client_programs/terms_term_id_terms.py' program that accesses the REST API searching for 'cancer' and received a long list of results (which is to be expected). By the way, the client was running on dev. I did not have to restart it. 